### PR TITLE
Update triton_file_write.py - change CVE ID

### DIFF
--- a/triton/triton_file_write.py
+++ b/triton/triton_file_write.py
@@ -32,7 +32,7 @@ metadata = {
     'license': 'MSF_LICENSE',
     'references': [
         {'type': 'url', 'ref': 'https://huntr.com/bounties/b27148e3-4da4-4e12-95ae-756d33d94687/'},
-        {'type': 'cve', 'ref': 'CVE-2023-6025'}
+        {'type': 'cve', 'ref': 'CVE-2023-31036'}
     ],
     'type': 'single_scanner',
     'options': {


### PR DESCRIPTION
Pretty sure CVE-2023-31036 covers this issue. The CVE that was present is not found anywhere. During our analysis we linked the NVIDIA disclosure / commit / Huntr.dev advisories, and the vendor assigned 2023-31036.