### PR TITLE
Update ray_cpuprofile_cmd_injection.py to set MeterpreterTryToFork True using default_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Nuclei is a vulnerability scanning engine which can be used to scan large number
 Navigate to nuclei templates folder such as `ai-exploits/mlflow/nuclei-templates`. In the Docker container these are stored in the `/root/nuclei-templates` folder. Then simply point to the template file and the target server.
    ```
    cd ai-exploits/mlflow/nuclei-templates
-   nuclei -t mlflow-lfi.yaml -u http://<target>:<port>`
+   nuclei -t mlflow-lfi.yaml -u http://<target>:<port>
    ```
 
 ### Using CSRF Templates

--- a/ray/README.md
+++ b/ray/README.md
@@ -45,6 +45,11 @@ Ray is an open-source framework that allows for distributed training of machine 
 - **ray-log-lfi**: Identifies Local File Inclusion vulnerabilities via log files in Ray.
 - **ray-static-lfi**: Detects Local File Inclusion vulnerabilities within static file serving in Ray.
 
+### Vulnerable ray setup for testing
+1. docker pull rayproject/ray:2.6.3
+2. docker run --shm-size=512M -it -p 8265:8265 rayproject/ray:2.6.3
+3. ray start --head --dashboard-host=0.0.0.0
+
 ## Reports
 
 - **Sierra Haex & @DanMcInerney**: https://huntr.com/bounties/d0290f3c-b302-4161-89f2-c13bb28b4cfe/

--- a/ray/msfmodules/ray_cpuprofile_cmd_injection.py
+++ b/ray/msfmodules/ray_cpuprofile_cmd_injection.py
@@ -39,8 +39,11 @@ metadata = {
     'targets': [
         {'platform': 'linux', 'arch': 'x64' },
         {'platform': 'linux', 'arch': 'x86'},
-        {'platform': 'linux', 'arch': 'aarch64'} #'default_options': { 'MeterpreterTryToFork': True} } ??
+        {'platform': 'linux', 'arch': 'aarch64'}
     ],
+    'default_options': {
+        'MeterpreterTryToFork': True
+    },
     'payload': {
         'command_stager_flavor': 'wget',
     },

--- a/ray/msfmodules/ray_lfi_static_file.py
+++ b/ray/msfmodules/ray_lfi_static_file.py
@@ -20,7 +20,7 @@ from metasploit import module
 metadata = {
     'name': 'Ray static arbitrary file read',
     'description': '''
-        Ray before 2.6.1 is vulnerable to a local file inclusion.
+        Ray before 2.6.3 is vulnerable to a local file inclusion.
     ''',
     'authors': [
         'byt3bl33d3r <marcello@protectai.com>',

--- a/ray/msfmodules/ray_lfi_static_file.py
+++ b/ray/msfmodules/ray_lfi_static_file.py
@@ -20,7 +20,7 @@ from metasploit import module
 metadata = {
     'name': 'Ray static arbitrary file read',
     'description': '''
-        Ray before 2.6.3 is vulnerable to a local file inclusion.
+        Ray before 2.8.1 is vulnerable to a local file inclusion.
     ''',
     'authors': [
         'byt3bl33d3r <marcello@protectai.com>',


### PR DESCRIPTION
Seems like default_options is now working fine.
https://github.com/rapid7/metasploit-framework/discussions/18556#discussioncomment-7720743

Test result
![default_options_working](https://github.com/user-attachments/assets/10238d16-7215-4f34-a91e-c101a1444276)

Also add vulnerable ray setup instruction and remove unnecessary backtick.