### PR TITLE
This uses the correct key=value format for setting environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN curl https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/conf
     && chmod 755 msfinstall \
     && ./msfinstall
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/opt/metasploit-framework/embedded/framework/lib/msf/core/modules/external/python
 
 COPY **/msfmodules/*.py /root/.msf4/modules/exploits/protectai/


### PR DESCRIPTION
The error suggests that the ENV command in your Dockerfile is using an outdated format. In Dockerfiles, the correct format for the ENV instruction is ENV key=value, while the legacy format uses a space (ENV key value), which is no longer recommended.